### PR TITLE
fix error with old hadoop-client libraries

### DIFF
--- a/tpcds-gen/pom.xml
+++ b/tpcds-gen/pom.xml
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client</artifactId>
-      <version>2.0.2-alpha</version>
+      <version>2.2.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
With hadoop-client version 2.0.2-alpha the following error occur when using with the latest Hadoop version:

Exception in thread "main" java.util.ServiceConfigurationError: org.apache.hadoop.fs.FileSystem: Provider org.apache.hadoop.hdfs.Hft
pFileSystem could not be instantiated: java.lang.IllegalAccessError: tried to access method org.apache.hadoop.fs.DelegationTokenRene
wer.<init>(Ljava/lang/Class;)V from class org.apache.hadoop.hdfs.HftpFileSystem (...)

Fixed by upgrading to 2.2.0
